### PR TITLE
fix: avoid error message on graceful shutdown

### DIFF
--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -581,6 +581,8 @@ class Arbiter(object):
     def stop(self):
         logger.info('Arbiter exiting')
         self._stopping = True
+        if self.ctrl.caller is not None:
+            self.ctrl.caller.stop()
         yield self._stop_watchers(close_output_streams=True)
         if self._provided_loop:
             cb = self.stop_controller_and_close_sockets


### PR DESCRIPTION
<img width="1225" alt="截屏2024-10-16 16 27 58" src="https://github.com/user-attachments/assets/7836457e-170a-4a0f-9288-2cc862c1a598">
